### PR TITLE
sleep on error for cloudwatch logs

### DIFF
--- a/lib/cody/cli.rb
+++ b/lib/cody/cli.rb
@@ -11,7 +11,7 @@ module Cody
     register(Init, "init", "init", "Set up initial .cody files.")
 
     common_options = Proc.new do
-      option :type, desc: "folder to use within .cody folder for different build types"
+      option :type, aliases: "t", desc: "folder to use within .cody folder for different build types"
       option :stack_name, desc: "Override the generated stack name. If you use this you must always specify it"
       option :wait, type: :boolean, default: true, desc: "Wait for operation to complete"
     end


### PR DESCRIPTION
* also add `-t` alias for `--type` option