### PR TITLE
Fix @properties[:managed_policy_arns]

### DIFF
--- a/lib/cody/role.rb
+++ b/lib/cody/role.rb
@@ -24,11 +24,7 @@ module Cody
         }
       }]
 
-      if @managed_policy_arns && !@managed_policy_arns.empty?
-        @properties[:managed_policy_arns] = @managed_policy_arns
-      else
-        @properties[:managed_policy_arns] = default_managed_policy_arns
-      end
+      @properties[:managed_policy_arns] ||= @managed_policy_arns || default_managed_policy_arns
 
       resource = {
         IamRole: {

--- a/spec/fixtures/app/.cody/role_empty_managed_iam_policy.rb
+++ b/spec/fixtures/app/.cody/role_empty_managed_iam_policy.rb
@@ -1,0 +1,1 @@
+managed_iam_policy # set to empty

--- a/spec/fixtures/app/.cody/role_empty_managed_policy_arns.rb
+++ b/spec/fixtures/app/.cody/role_empty_managed_policy_arns.rb
@@ -1,0 +1,1 @@
+managed_policy_arns([])

--- a/spec/fixtures/app/.cody/role_with_managed_iam_policy.rb
+++ b/spec/fixtures/app/.cody/role_with_managed_iam_policy.rb
@@ -1,0 +1,1 @@
+managed_iam_policy('AmazonSNSReadOnlyAccess')

--- a/spec/fixtures/app/.cody/role_with_managed_policy_arns.rb
+++ b/spec/fixtures/app/.cody/role_with_managed_policy_arns.rb
@@ -1,0 +1,1 @@
+managed_policy_arns(["arn:aws:iam::aws:policy/AmazonSNSReadOnlyAccess"])

--- a/spec/lib/role_spec.rb
+++ b/spec/lib/role_spec.rb
@@ -1,12 +1,57 @@
 describe Cody::Role do
-  let(:role) do
-    Cody::Role.new(role_path: "spec/fixtures/app/.cody/role.rb")
-  end
+  let(:role) { Cody::Role.new(role_path: role_path) }
+  let(:role_path) { "spec/fixtures/app/.cody/role.rb" }
+  subject(:template) { role.run }
+
   context "general" do
     it "builds up the template in memory" do
-      template = role.run
       expect(template.keys).to eq ["IamRole"]
       expect(template["IamRole"]).to be_a(Hash)
+    end
+
+    it "sets default properties" do
+      expect(template["IamRole"]["Properties"]["Path"]).to eq("/")
+      expect(template["IamRole"]["Properties"]["AssumeRolePolicyDocument"]).to eq({
+        "Statement" => [{
+          "Action" => ["sts:AssumeRole"],
+          "Effect" => "Allow",
+          "Principal" => { "Service" => ["codebuild.amazonaws.com"]
+          }
+        }],
+        "Version" => "2012-10-17"
+      })
+      expect(template["IamRole"]["Properties"]["ManagedPolicyArns"]).to eq([
+        "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"])
+    end
+  end
+
+  context "empty managed_policy_arns value" do
+    let(:role_path) { "spec/fixtures/app/.cody/role_empty_managed_policy_arns.rb" }
+    it "sets ManagedPolicyArns to empty" do
+      expect(template["IamRole"]["Properties"]["ManagedPolicyArns"]).to eq([])
+    end
+  end
+
+  context "empty managed_iam_policy" do
+    let(:role_path) { "spec/fixtures/app/.cody/role_empty_managed_iam_policy.rb" }
+    it "sets default ManagedPolicyArns" do
+      expect(template["IamRole"]["Properties"]["ManagedPolicyArns"]).to eq([])
+    end
+  end
+
+  context "with managed_policy_arns value" do
+    let(:role_path) { "spec/fixtures/app/.cody/role_with_managed_policy_arns.rb" }
+    it "sets ManagedPolicyArns to value" do
+      expect(template["IamRole"]["Properties"]["ManagedPolicyArns"]).to eq([
+        "arn:aws:iam::aws:policy/AmazonSNSReadOnlyAccess"])
+    end
+  end
+
+  context "with managed_iam_policy value" do
+    let(:role_path) { "spec/fixtures/app/.cody/role_with_managed_iam_policy.rb" }
+    it "sets ManagedPolicyArns to value" do
+      expect(template["IamRole"]["Properties"]["ManagedPolicyArns"]).to eq([
+        "arn:aws:iam::aws:policy/AmazonSNSReadOnlyAccess"])
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/tongueroo/cody/issues/15

* Don't override if it's already set
* Allow setting empty list @managed_policy_arns

I wrote an rspec for this, but couldn't run it due to https://github.com/tongueroo/cody/issues/16
I tested manually and confirmed the following cases are working:
* Empty list `managed_iam_policy`
* Add a different policy arn to `managed_policy_arns`
* Specify neither `managed_iam_policy` or `managed_policy_arns`