### PR TITLE
Fix subnet ids key name

### DIFF
--- a/docs/_docs/variables.md
+++ b/docs/_docs/variables.md
@@ -94,13 +94,13 @@ A good variables example is running migrations. The migration tasks usually requ
 .cody/variables/development.rb:
 
 ```ruby
-@vpc_config = { vpc_id: "vpc-aaa", subnet_ids: ["subnet-aaa"], security_group_ids: ["sg-111"]  }
+@vpc_config = { vpc_id: "vpc-aaa", subnets: ["subnet-aaa"], security_group_ids: ["sg-111"]  }
 ```
 
 .cody/variables/production.rb:
 
 ```ruby
-@vpc_config = { vpc_id: "vpc-bbb", subnet_ids: ["subnet-bbb"], security_group_ids: ["sg-222"]  }
+@vpc_config = { vpc_id: "vpc-bbb", subnets: ["subnet-bbb"], security_group_ids: ["sg-222"]  }
 ```
 
 You'll use then `@vpc_config` variable in the `project.rb`.


### PR DESCRIPTION
Hi @tongueroo !

I found the wrong key designation in the Cody documentation.

https://docs.aws.amazon.com/us_en/codebuild/latest/userguide/codebuild-user.pdf

![image](https://user-images.githubusercontent.com/1491043/81039889-19d0f100-8ee5-11ea-9e5d-ae4a64939360.png)

If you want to specify a subnet with CodeBuild, you should specify it with `subnets` instead of `subnet_id`.

Check it out, please!