### PR TITLE
Allow multiple git providers

### DIFF
--- a/lib/cody/dsl/project.rb
+++ b/lib/cody/dsl/project.rb
@@ -33,8 +33,13 @@ module Cody::Dsl
     end
 
     # Convenience wrapper methods
-    def git_type(type="GITHUB")
+    def git_provider(type="GITHUB")
       @properties[:Source][:Type] = type
+    end
+
+    # Convenience wrapper methods
+    def git_branch(branch_or_tag)
+      @properties[:SourceVersion] = branch_or_tag
     end
 
     def buildspec(file=".cody/buildspec.yaml")
@@ -59,8 +64,11 @@ module Cody::Dsl
         GitCloneDepth: 1,
         GitSubmodulesConfig: { fetch_submodules: true },
         BuildSpec: options[:BuildSpec] || ".cody/buildspec.yml", # options[:Buildspec] accounts for type already
-        ReportBuildStatus: true,
       }
+
+      if source[:Type] =~ /GITHUB/
+        source[:ReportBuildStatus] = true
+      end
 
       if options[:OauthToken]
         source[:Auth] = {

--- a/lib/cody/dsl/project.rb
+++ b/lib/cody/dsl/project.rb
@@ -32,6 +32,11 @@ module Cody::Dsl
       @properties[:Source][:Location] = url
     end
 
+    # Convenience wrapper methods
+    def git_type(type="GITHUB")
+      @properties[:Source][:Type] = type
+    end
+
     def buildspec(file=".cody/buildspec.yaml")
       @properties[:Source][:BuildSpec] = file
     end
@@ -49,7 +54,7 @@ module Cody::Dsl
 
     def github_source(options={})
       source = {
-        Type: "GITHUB",
+        Type: options[:Type] || "GITHUB",
         Location: options[:Location],
         GitCloneDepth: 1,
         GitSubmodulesConfig: { fetch_submodules: true },

--- a/lib/cody/project.rb
+++ b/lib/cody/project.rb
@@ -53,7 +53,6 @@ module Cody
           #   Type: "OAUTH",
           #   # Resource: "", # required
           # },
-          ReportBuildStatus: true,
         }
       }
     end

--- a/lib/cody/version.rb
+++ b/lib/cody/version.rb
@@ -1,3 +1,3 @@
 module Cody
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
https://github.com/boltops-tools/cody/issues/29

Making the Type configurable allows for multiple providers.
Also, the ReportBuildStatus must be configurable (not always present), since code commit doesn't support that option, and actually raises an error wen it is set.

With these changes I was able to run the deploy command successfully for a codecommit repository.