### PR TITLE
fix activesupport require

### DIFF
--- a/lib/cody.rb
+++ b/lib/cody.rb
@@ -1,4 +1,6 @@
 $:.unshift(File.expand_path("../", __FILE__))
+require 'active_support'
+require 'active_support/core_ext/string'
 require "aws_data"
 require "cfn_camelizer"
 require "cfn_status"

--- a/lib/cody/core.rb
+++ b/lib/cody/core.rb
@@ -1,6 +1,5 @@
 require 'pathname'
 require 'yaml'
-require 'active_support/core_ext/string'
 
 module Cody
   module Core


### PR DESCRIPTION
Related:

* https://github.com/boltops-tools/terraspace/pull/164
* https://github.com/boltops-tools/ufo/pull/122

Note: Looks like don't have to `require "active_support/all"`, just need to `require "active_support"` first.