### PR TITLE
iam roles: support multiple calls

### DIFF
--- a/cody.gemspec
+++ b/cody.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cfn-status"
   spec.add_dependency "cfn_camelizer"
   spec.add_dependency "cli-format"
+  spec.add_dependency "dsl_evaluator"
   spec.add_dependency "memoist"
   spec.add_dependency "rainbow"
   spec.add_dependency "render_me_pretty"

--- a/lib/cody.rb
+++ b/lib/cody.rb
@@ -1,10 +1,11 @@
 $:.unshift(File.expand_path("../", __FILE__))
-require 'active_support'
-require 'active_support/core_ext/string'
+require "active_support"
+require "active_support/core_ext/string"
 require "aws_data"
 require "cfn_camelizer"
 require "cfn_status"
 require "cody/version"
+require "dsl_evaluator"
 require "memoist"
 require "rainbow/ext/string"
 require "yaml"

--- a/lib/cody/dsl/role/registry.rb
+++ b/lib/cody/dsl/role/registry.rb
@@ -1,0 +1,25 @@
+require "set"
+
+module Cody::Dsl::Role
+  class Registry
+    class_attribute :iam_statements
+    self.iam_statements = nil # nil to allow fallback to default_iam_statements in cody/role.rb
+    class_attribute :managed_policy_arns
+    self.managed_policy_arns = nil # nil to allow fallback to default_managed_policy_arns in cody/role.rb
+
+    class << self
+      def register_policy(*statements)
+        statements.flatten!
+        self.iam_statements ||= []
+        self.iam_statements += statements # using set so DSL can safely be evaluated multiple times
+      end
+
+      def register_managed_policy(*policies)
+        policies.flatten!
+        self.managed_policy_arns ||= []
+        self.managed_policy_arns += policies # using set so DSL can safely be evaluated multiple times
+        self.managed_policy_arns.uniq!
+      end
+    end
+  end
+end

--- a/lib/cody/evaluate.rb
+++ b/lib/cody/evaluate.rb
@@ -1,46 +1,7 @@
 module Cody
   module Evaluate
+    include DslEvaluator
     include Interface
-
-    def evaluate(path)
-      source_code = IO.read(path)
-      begin
-        instance_eval(source_code, path)
-      rescue Exception => e
-        if e.class == SystemExit # allow exit to happen normally
-          raise
-        else
-          task_definition_error(e)
-          puts "\nFull error:"
-          raise
-        end
-      end
-    end
-
-  private
-    # Prints out a user friendly task_definition error message
-    def task_definition_error(e)
-      error_info = e.backtrace.first
-      path, line_no, _ = error_info.split(':')
-      line_no = line_no.to_i
-      puts "Error evaluating #{path}:".color(:red)
-      puts e.message
-      puts "Here's the line in #{path} with the error:\n\n"
-
-      contents = IO.read(path)
-      content_lines = contents.split("\n")
-      context = 5 # lines of context
-      top, bottom = [line_no-context-1, 0].max, line_no+context-1
-      spacing = content_lines.size.to_s.size
-      content_lines[top..bottom].each_with_index do |line_content, index|
-        line_number = top+index+1
-        if line_number == line_no
-          printf("%#{spacing}d %s\n".color(:red), line_number, line_content)
-        else
-          printf("%#{spacing}d %s\n", line_number, line_content)
-        end
-      end
-    end
 
     def lookup_cody_file(name)
       [".cody", @options[:type], name].compact.join("/")

--- a/lib/cody/project.rb
+++ b/lib/cody/project.rb
@@ -18,7 +18,7 @@ module Cody
 
     def run
       load_variables
-      evaluate(@project_path)
+      evaluate_file(@project_path)
       resource = {
         CodeBuild: {
           Type: "AWS::CodeBuild::Project",

--- a/lib/cody/schedule.rb
+++ b/lib/cody/schedule.rb
@@ -15,7 +15,7 @@ module Cody
 
       old_properties = @properties.clone
       load_variables
-      evaluate(@schedule_path)
+      evaluate_file(@schedule_path)
 
       @properties[:ScheduleExpression] = @schedule_expression if @schedule_expression
       set_rule_event! if @rule_event_props

--- a/lib/cody/stack/base.rb
+++ b/lib/cody/stack/base.rb
@@ -41,6 +41,7 @@ class Cody::Stack
       FileUtils.mkdir_p(File.dirname(template_path))
       IO.write(template_path, YAML.dump(@template))
       puts "Generated CloudFormation template at #{template_path.color(:green)}"
+
       return if @options[:noop]
       puts "Deploying stack #{@stack_name.color(:green)} with CodeBuild project #{@full_project_name.color(:green)}"
 


### PR DESCRIPTION
Before, only this worked:

```ruby
iam_policy(
  "cloudformation",
  "ec2",
)
```

With this PR, now this works:

```ruby
iam_policy("cloudformation")
iam_policy("ec2")
```